### PR TITLE
Track dependencies via go modules, prepare Dockerfile for auto build and deployment as Docker service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+random-event-bot

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+random-event-bot

--- a/config.go
+++ b/config.go
@@ -6,14 +6,12 @@ import (
 	"path/filepath"
 )
 
-const configFile = "./config.yml"
-
 type Config struct {
 	Token string `json:"token"`
 }
 
-func GetConfig() (*Config, error) {
-	filename, err := filepath.Abs(configFile)
+func GetConfig(cfgPath string) (*Config, error) {
+	filename, err := filepath.Abs(cfgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,1 @@
+token: <to be specified>

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/pachmu/random-event-bot
+
+go 1.12
+
+require (
+	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
+	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
+github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
+github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
+github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"time"
 
 	"github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
+var configPath = flag.String("config", "", "Path to config file")
+
 func main() {
-	config, err := GetConfig()
+	flag.Parse()
+	config, err := GetConfig(*configPath)
 	if err != nil {
 		log.Panic(err)
 		return


### PR DESCRIPTION
* Switch to go modules to track dependencies and pin specific versions
* Switch to multi-stage Docker build to reduce final image size
* Allow to specify a config file path via command line args as a preparation for deployment as a Docker service